### PR TITLE
Implement part of platform API, and various fixes

### DIFF
--- a/CPU Tests/main.c
+++ b/CPU Tests/main.c
@@ -2,8 +2,8 @@
  * Program Name: CoreCoherencyTest
  * File Name: main.c
  * Date Created: January 21, 2024
- * Date Updated: February 5, 2024
- * Version: 0.1.1
+ * Date Updated: October 16, 2024
+ * Version: 0.1.2
  * Purpose: Test Core-to-Core Latency of Multi-Core CPU's using Coherency checks.
  */
 

--- a/Framework/platformCode.h
+++ b/Framework/platformCode.h
@@ -4,8 +4,8 @@
  * Program Name: CnC Common Headers
  * File Name: platformCode.h
  * Date Created: January 21, 2024
- * Date Updated: January 29, 2024
- * Version: 0.1
+ * Date Updated: October 16, 2024
+ * Version: 0.2
  * Purpose: This file contains all functions that interact with platform-specific functionality
  */
 

--- a/Framework/timing.h
+++ b/Framework/timing.h
@@ -4,8 +4,8 @@
  * Program Name: CnC Common Headers
  * File Name: timing.h
  * Date Created: January 24, 2024
- * Date Updated: August 31, 2024
- * Version: 0.4
+ * Date Updated: October 16, 2024
+ * Version: 0.5
  * Purpose: Provides a function to time the execution of the passed in function.
  */
 #ifndef timespec


### PR DESCRIPTION
System: Debian 12
Compilers Tested: clang 14.0.6, gcc 12.2.0, mingw-gcc 12
I implemented part of the threading API for POSIX and Windows systems, the code successfully compiled and ran on Linux and Windows.
Smaller fixes were also implemented to make this compile more reliably for separate compilers.